### PR TITLE
Create danger.yml

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,16 @@
+name: Danger Action
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Run Danger"
+    steps:
+      - uses: actions/checkout@v1
+      - name: Danger
+        uses: danger/kotlin@0.2.0
+        with:
+          args: "--id DangerKotlinAction"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Was thinking we could run the danger kotlin action on the repo itself, to be sure it still work, maybe we can use another dangerfile for it in the future, to avoid to get the same message twice