### PR TITLE
Restore meta to get the correct danger signature

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/com/danger/dangerkotlin/DangerResults.kt
+++ b/danger-kotlin-library/src/main/kotlin/com/danger/dangerkotlin/DangerResults.kt
@@ -4,10 +4,9 @@ internal data class DangerResults(
     var fails: Array<Violation> = arrayOf(),
     var warnings: Array<Violation> = arrayOf(),
     var messages: Array<Violation> = arrayOf(),
-    var markdowns: Array<Violation> = arrayOf()
-) {
+    var markdowns: Array<Violation> = arrayOf(),
     val meta: Meta = Meta()
-
+) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false


### PR DESCRIPTION
Moving meta out from the constructor broke the danger kotlin signature