### PR TITLE
Add extension for changed lines in GitLab MR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
 
 ## Master
 
+- Add extensions for changed lines in Git [@davidbilik][] - [#102](https://github.com/danger/kotlin/pull/102)
 - Add exec function [@f-meloni][] - [#97](https://github.com/danger/kotlin/pull/97)
 - Add readFile function [@f-meloni][] - [#93](https://github.com/danger/kotlin/pull/93)
 - Github exposing user avatar [@gianluz] - [#96](https://github.com/danger/kotlin/pull/96)
 
 [@f-meloni]: https://github.com/f-meloni
 [@gianluz]: https://github.com/gianluz
+[@davidbilik]: https://github.com/davidbilik

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/Git.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/Git.kt
@@ -16,7 +16,8 @@ typealias FilePath = String
 data class Git(
     @Json(name = "modified_files") val modifiedFiles: Array<FilePath>,
     @Json(name = "created_files") val createdFiles: Array<FilePath>,
-    @Json(name = "deleted_files") val deletedFiles: Array<FilePath>
+    @Json(name = "deleted_files") val deletedFiles: Array<FilePath>,
+    @Json(name = "commits") val commits: List<GitCommit>
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/GitKtx.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/GitKtx.kt
@@ -1,0 +1,59 @@
+package systems.danger.kotlin
+
+// extensions over [Git] object
+
+/**
+ * Changed lines in this MR
+ */
+val Git.changedLines: PullRequestChangedLines
+    get() {
+        // TODO replace with more generic way to process commands
+        val utils = Utils()
+        val additionDeletionPairs = commits.mapNotNull { it.sha }
+            .map { sha ->
+                computeChangedLinesForCommit(utils, sha)
+            }.flatten()
+
+        val additions = additionDeletionPairs.fold(0) { acc, (addition, _) -> acc + addition }
+        val deletions = additionDeletionPairs.fold(0) { acc, (_, deletion) -> acc + deletion }
+        return PullRequestChangedLines(additions, deletions)
+    }
+
+private fun computeChangedLinesForCommit(
+    utils: Utils,
+    sha: String
+): List<Pair<Int, Int>> {
+    val commandRawOutput = utils.exec("git diff --numstat $sha $sha^1")
+    return commandRawOutput.lines()
+        .filter { it.isNotEmpty() }
+        .map { line ->
+            val parts = line.split("\\s+".toRegex())
+            parts[0].toInt() to parts[1].toInt()
+        }
+}
+
+/**
+ * Number of changed lines
+ */
+val Git.linesOfCode: Int
+    get() = additions + deletions
+
+/**
+ * Number of added lines
+ */
+val Git.additions: Int
+    get() = changedLines.additions
+
+/**
+ * Number of deleted lines
+ */
+val Git.deletions: Int
+    get() = changedLines.deletions
+
+/**
+ * Wrapper for number of additions and deletions in currently processed Pull (or Merge) Request
+ */
+data class PullRequestChangedLines(
+    val additions: Int,
+    val deletions: Int
+)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/Utils.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/Utils.kt
@@ -17,13 +17,13 @@ class Utils {
      * Gives you the ability to cheaply run a command and read the output without having to mess around
      *
      * @param command The first part of the command
-     * @param arguments An optional array of arguements to pass in extra
+     * @param arguments An optional array of arguments to pass in extra
      * @return the stdout from the command
      */
     fun exec(command: String, arguments: Array<String> = arrayOf()): String {
-        val commandToExec = "/bin/bash -c $command" + if (arguments.isNotEmpty())  " " + arguments.joinToString(" ") else ""
+        val commandWithArgs = command + if (arguments.isNotEmpty())  " " + arguments.joinToString(" ") else ""
 
-        val process = Runtime.getRuntime().exec(commandToExec)
+        val process = Runtime.getRuntime().exec(arrayOf("/bin/bash", "-c", commandWithArgs))
         process.waitFor()
 
         return process.inputStream.bufferedReader().readText()


### PR DESCRIPTION
Since GitLab does not provide number of added/deleted lines
in Merge requests add artificial properties that are computed
through `git` command.

Related: #GH-101