### PR TITLE
Introduce ShellExecutor, add tests for GitKtx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Add abstraction for executing shell commands via `ShellExecutor` [@davidbilik][] - [#105](https://github.com/danger/kotlin/pull/105)
+
 # 0.6.0
 
 - Fix to allow for large GitHub id values [@brentwatson][] - [#108](https://github.com/danger/kotlin/pull/108)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/Utils.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/Utils.kt
@@ -1,5 +1,6 @@
 package systems.danger.kotlin
 
+import systems.danger.kotlin.shell.ShellExecutorFactory
 import java.io.File
 
 class Utils {
@@ -17,15 +18,10 @@ class Utils {
      * Gives you the ability to cheaply run a command and read the output without having to mess around
      *
      * @param command The first part of the command
-     * @param arguments An optional array of arguments to pass in extra
+     * @param arguments An optional list of arguments to pass in extra
      * @return the stdout from the command
      */
-    fun exec(command: String, arguments: Array<String> = arrayOf()): String {
-        val commandWithArgs = command + if (arguments.isNotEmpty())  " " + arguments.joinToString(" ") else ""
-
-        val process = Runtime.getRuntime().exec(arrayOf("/bin/bash", "-c", commandWithArgs))
-        process.waitFor()
-
-        return process.inputStream.bufferedReader().readText()
+    fun exec(command: String, arguments: List<String> = emptyList()): String {
+       return ShellExecutorFactory.get().execute(command, arguments)
     }
 }

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/shell/ShellExecutor.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/shell/ShellExecutor.kt
@@ -1,0 +1,36 @@
+package systems.danger.kotlin.shell
+
+interface ShellExecutor {
+
+    /**
+     * Execute [command] with optional list of arguments and return output from
+     * stdout
+     */
+    fun execute(command: String, arguments: List<String> = emptyList()): String
+}
+
+class ShellExecutorImpl : ShellExecutor {
+
+    override fun execute(command: String, arguments: List<String>): String {
+        val commandWithArgs = command + if (arguments.isNotEmpty()) " " + arguments.joinToString(" ") else ""
+
+        val process = Runtime.getRuntime().exec(arrayOf("/bin/bash", "-c", commandWithArgs))
+        process.waitFor()
+
+        return process.inputStream.bufferedReader().readText()
+    }
+}
+
+object ShellExecutorFactory {
+
+    private var shellExecutor: ShellExecutor = ShellExecutorImpl()
+
+    /**
+     * Useful for testing
+     */
+    internal fun set(executor: ShellExecutor) {
+        this.shellExecutor = executor
+    }
+
+    fun get() = shellExecutor
+}

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitKtxTest.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitKtxTest.kt
@@ -1,9 +1,10 @@
 package systems.danger.kotlin
 
+import io.mockk.every
+import io.mockk.mockk
 import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import systems.danger.kotlin.shell.ShellExecutor
 import systems.danger.kotlin.shell.ShellExecutorFactory
 
 /**
@@ -11,8 +12,7 @@ import systems.danger.kotlin.shell.ShellExecutorFactory
  */
 internal class GitKtxTest {
 
-    class MockShellExecutor : ShellExecutor {
-
+    companion object {
         private val diffCommandOutput = """
         0       1       features/search/build.gradle
         3       10      features/search/src/main/java/com/sampleapp/search/di/RepositoryModule.kt
@@ -20,10 +20,6 @@ internal class GitKtxTest {
         2       4       features/search/src/main/java/com/sampleapp/search/model/RecommendedPublishersRepository.kt
         1       3       features/search/src/main/java/com/sampleapp/search/model/RecommendedTopicsRepository.kt
         """.trimIndent()
-
-        override fun execute(command: String, arguments: List<String>): String {
-            return diffCommandOutput
-        }
     }
 
     private val basicGit = Git(
@@ -46,7 +42,9 @@ internal class GitKtxTest {
 
     @Before
     fun setup() {
-        ShellExecutorFactory.set(MockShellExecutor())
+        ShellExecutorFactory.set(mockk {
+            every { execute(any(), any()) } returns diffCommandOutput
+        })
     }
 
     @Test

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitKtxTest.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitKtxTest.kt
@@ -19,7 +19,7 @@ internal class GitKtxTest {
         2       4       features/search/src/main/java/com/sampleapp/search/model/ApiInteractor.kt
         2       4       features/search/src/main/java/com/sampleapp/search/model/RecommendedPublishersRepository.kt
         1       3       features/search/src/main/java/com/sampleapp/search/model/RecommendedTopicsRepository.kt
-    """.trimIndent()
+        """.trimIndent()
 
         override fun execute(command: String, arguments: List<String>): String {
             return diffCommandOutput

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitKtxTest.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitKtxTest.kt
@@ -1,0 +1,77 @@
+package systems.danger.kotlin
+
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import systems.danger.kotlin.shell.ShellExecutor
+import systems.danger.kotlin.shell.ShellExecutorFactory
+
+/**
+ * Tests for [Git] extensions
+ */
+internal class GitKtxTest {
+
+    class MockShellExecutor : ShellExecutor {
+
+        private val diffCommandOutput = """
+        0       1       features/search/build.gradle
+        3       10      features/search/src/main/java/com/sampleapp/search/di/RepositoryModule.kt
+        2       4       features/search/src/main/java/com/sampleapp/search/model/ApiInteractor.kt
+        2       4       features/search/src/main/java/com/sampleapp/search/model/RecommendedPublishersRepository.kt
+        1       3       features/search/src/main/java/com/sampleapp/search/model/RecommendedTopicsRepository.kt
+    """.trimIndent()
+
+        override fun execute(command: String, arguments: List<String>): String {
+            return diffCommandOutput
+        }
+    }
+
+    private val basicGit = Git(
+        modifiedFiles = emptyArray(),
+        createdFiles = emptyArray(),
+        deletedFiles = emptyArray(),
+        commits = listOf(
+            GitCommit(
+                sha = "commit1",
+                author = GitCommitAuthor("John Doe", "john@doe.com", "now"),
+                committer = GitCommitAuthor("John Doe", "john@doe.com", "now"),
+                message = "Random message",
+                parents = null,
+                url = ""
+            )
+        )
+    )
+
+    private val expectedResult = PullRequestChangedLines(22, 8)
+
+    @Before
+    fun setup() {
+        ShellExecutorFactory.set(MockShellExecutor())
+    }
+
+    @Test
+    fun testItCorrectlyParseDiff() {
+        assertEquals(expectedResult, basicGit.changedLines)
+    }
+
+    @Test
+    fun testAdditionsAreCorrect() {
+        assertEquals(expectedResult.additions, basicGit.additions)
+    }
+
+    @Test
+    fun testDeletionsAreCorrect() {
+        assertEquals(expectedResult.deletions, basicGit.deletions)
+    }
+
+    @Test
+    fun testLinesOfCodeAreCorrect() {
+        assertEquals(expectedResult.deletions + expectedResult.additions, basicGit.linesOfCode)
+    }
+
+    @Test
+    fun testNoChangedLinesForNoCommits() {
+        val gitWOCommits = basicGit.copy(commits = emptyList())
+        assertEquals(PullRequestChangedLines(0, 0), gitWOCommits.changedLines)
+    }
+}

--- a/dependencyVersions.gradle
+++ b/dependencyVersions.gradle
@@ -40,9 +40,14 @@ ext.kotlinDependencies = group {
 project.ext.versionJunit = '4.12'
 project.ext.groupIdJunit = 'junit'
 project.ext.artifactIdJunit = 'junit'
+project.ext.versionMockK = "1.10.0"
+project.ext.groupIdMockK = "io.mockk"
+project.ext.artifactIdMockK = "mockk"
 ext.testing = [
-        junit: "junit:junit:$versionJunit"
+        junit: "junit:junit:$versionJunit",
+        mockK: "$groupIdMockK:$artifactIdMockK:$versionMockK"
 ]
 ext.testingDependencies = group {
     testImplementation testing.junit
+    testImplementation testing.mockK
 }


### PR DESCRIPTION
Introduce abstract ShellExecutor with one specific implementation
used in production code. This is useful for tests when we want to
isolate our test from actual shell commands. Use this abstraction in
tests for Git changed lines extensions.