### PR TITLE
Fix invalid parsing of changes in diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 -->
 
 ## Master
-
+- Fix invalid parsing of changes in diff [@davidbilik][] - [#106](https://github.com/danger/kotlin/pull/106)
 - Add extensions for changed lines in Git [@davidbilik][] - [#102](https://github.com/danger/kotlin/pull/102)
 - Add exec function [@f-meloni][] - [#97](https://github.com/danger/kotlin/pull/97)
 - Add readFile function [@f-meloni][] - [#93](https://github.com/danger/kotlin/pull/93)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/GitKtx.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/GitKtx.kt
@@ -14,7 +14,7 @@ val Git.changedLines: PullRequestChangedLines
             .filter { it.isNotEmpty() }
             .map { line ->
                 val parts = line.split("\\s+".toRegex())
-                parts[0].toInt() to parts[1].toInt()
+                (parts[0].toIntOrNull() ?: 0) to (parts[1].toIntOrNull() ?: 0)
             }
         val additions = additionDeletionPairs.fold(0) { acc, (addition, _) -> acc + addition }
         val deletions = additionDeletionPairs.fold(0) { acc, (_, deletion) -> acc + deletion }


### PR DESCRIPTION
When file is binary git do not display numbers in diff but dashes
instead. Use fail parsing of integers and fallback to zero when error
happens.