### PR TITLE
Fix crash on large GitHub "id" values

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/GitHub.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/GitHub.kt
@@ -173,7 +173,7 @@ data class GitHubPR(
  */
 @JsonClass(generateAdapter = true)
 data class GitHubTeam(
-    val id: Int,
+    val id: Long,
     val name: String
 )
 
@@ -238,7 +238,7 @@ data class GitHubMergeRef(
  */
 @JsonClass(generateAdapter = true)
 data class GitHubRepo(
-    val id: Int,
+    val id: Long,
     val name: String,
     @Json(name = "full_name") val fullName: String,
     @Json(name = "private") val isPrivate: Boolean,
@@ -272,7 +272,7 @@ enum class GitHubReviewState(val value: String) {
 @JsonClass(generateAdapter = true)
 data class GitHubReview(
     val user: GitHubUser,
-    val id: Int?,
+    val id: Long?,
     val body: String?,
     @Json(name = "commit_id") val commitId: String?,
     val state: GitHubReviewState?
@@ -333,7 +333,7 @@ enum class GitHubIssueState(val value: String) {
  */
 @JsonClass(generateAdapter = true)
 data class GitHubIssue(
-    val id: Int,
+    val id: Long,
     val number: Int,
     val title: String,
     val user: GitHubUser,
@@ -375,7 +375,7 @@ data class GitHubIssue(
     }
 
     override fun hashCode(): Int {
-        var result = id
+        var result = id.hashCode()
         result = 31 * result + number
         result = 31 * result + title.hashCode()
         result = 31 * result + user.hashCode()
@@ -402,7 +402,7 @@ data class GitHubIssue(
  */
 @JsonClass(generateAdapter = true)
 data class GitHubIssueLabel(
-        val id: Int,
+        val id: Long,
         val url: String,
         val name: String,
         val color: String
@@ -426,7 +426,7 @@ enum class GitHubUserType {
  */
 @JsonClass(generateAdapter = true)
 data class GitHubUser(
-    val id: Int,
+    val id: Long,
     val login: String,
     val type: GitHubUserType,
     @Json(name="avatar_url")
@@ -460,7 +460,7 @@ enum class GitHubMilestoneState(val value: String) {
  */
 @JsonClass(generateAdapter = true)
 data class GitHubMilestone(
-    val id: Int,
+    val id: Long,
     val number: Int,
     val state: GitHubMilestoneState,
     val title: String,

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitHubParsingTests.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/GitHubParsingTests.kt
@@ -138,7 +138,7 @@ class GitHubParsingTests {
     @Test
     fun testItCorrectlyParsesTheIssue() {
         with(github.issue) {
-            assertEquals(167696965, id)
+            assertEquals(2190001234, id)
             assertEquals(609, number)
             assertEquals("Xcode updates", title)
             assertEquals(

--- a/danger-kotlin-library/src/test/resources/githubDangerJSON.json
+++ b/danger-kotlin-library/src/test/resources/githubDangerJSON.json
@@ -371,7 +371,7 @@
           "comments_url": "https://api.github.com/repos/artsy/eidolon/issues/609/comments",
           "events_url": "https://api.github.com/repos/artsy/eidolon/issues/609/events",
           "html_url": "https://github.com/artsy/eidolon/pull/609",
-          "id": 167696965,
+          "id": 2190001234,
           "number": 609,
           "title": "Xcode updates",
           "user": {


### PR DESCRIPTION
Recently experienced this crash:

```
com.squareup.moshi.JsonDataException: Expected an int but was 2185200023 at path $.danger.github.issue.labels[0].id
```

Looks like we have a PR with an `id` value larger than `Int.MAX_VALUE` (`2147483647`). Future proofing by updating all `id` values from int to long.