### PR TITLE
Fix url to kotlin compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Master
 - Update Kotlin to 1.4.10 [@gianluz] [#140](https://github.com/danger/kotlin/pull/140)
 - Migrate from moshi to kotlinx serialization [@gianluz] [#141] (https://github.com/danger/kotlin/pull/141)
+- Fix incorrect url in install.sh script and in Dockerfile [@davidbilik][] - [#144](https://github.com/danger/kotlin/pull/144)
 
 # 0.7.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash - && \
 # Install danger-kotlin globally
 COPY . /usr/local/_danger-kotlin
 RUN cd /usr/lib && \
-    wget -q https://github.com/JetBrains/kotlin/releases/download/v1.4.10/kotlin-compiler-1.4.0.zip && \
+    wget -q https://github.com/JetBrains/kotlin/releases/download/v1.4.10/kotlin-compiler-1.4.10.zip && \
     unzip kotlin-compiler-*.zip && \
     rm kotlin-compiler-*.zip && \
     cd /usr/local/_danger-kotlin && \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ fi
 
 if ! [[ -x "$(command -v kotlinc)" ]]; then
     echo "Installing kotlin compiler 1.4.10"
-    curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v1.4.10/kotlin-compiler-1.4.0.zip
+    curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v1.4.10/kotlin-compiler-1.4.10.zip
     unzip -d /usr/local/ kotlin-compiler.zip
     echo 'export PATH=/usr/local/kotlinc/bin:$PATH' >> ~/.bash_profile
     rm -rf kotlin-compiler.zip


### PR DESCRIPTION
In the commit 2910f5cf40a4813586e7144525402c728d4ab32c was 
incorrectly replaced url, the version was not changed in the
zip file.