### PR TITLE
Use fixed repo version in install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix gitlab defaults following kotlinx serialisation [@gianluz] - [#146](https://github.com/danger/kotlin/pull/146)
 - Road to 1.0 - Migrate from java.util.Date to kotlinx.datetime [@gianluz] - [#147](https://github.com/danger/kotlin/pull/147)
 - Fix typo in Github Milestone serialization [@doodeec] - [#151](https://github.com/danger/kotlin/pull/151)
+- Use fixed commit of danger/kotlin repository in install.sh script [@davidbilik]- [#152](https://github.com/danger/kotlin/pull/152)
 
 # 0.7.1
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,7 +38,8 @@ if ! [[ -x "$(command -v gradle)" ]]; then
     rm -rf gradle.zip
 fi
 
-git clone https://github.com/danger/kotlin.git --single-branch --depth 1 _danger-kotlin
+LATEST_STABLE_VERSION=0.7.1
+git clone https://github.com/danger/kotlin.git --branch $LATEST_STABLE_VERSION --depth 1 _danger-kotlin
 cd _danger-kotlin && make install
 cd ..
 rm -rf _danger-kotlin


### PR DESCRIPTION
To avoid cloning the newest version of the repository which may
not be stable in the `install.sh` script use specific git tag
when cloning the repo pointing to the latest stable release.