### PR TITLE
Fixed body parameter in github models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 -->
 ## Master
 
+- Fix body parameter in github models  [@tegorov] - [#175](https://github.com/danger/kotlin/pull/175)
+
 # 1.0.0-beta2
 
 - Update kotlinx-datetime to 0.1.1 [@f-meloni] - [@gianluz] - [#167](https://github.com/danger/kotlin/pull/167)
@@ -68,3 +70,4 @@
 [@anton46]: https://github.com/anton46
 [@uzzu]: https://github.com/uzzu
 [@mariusgreve]: https://github.com/mariusgreve
+[@tegorov]: https://github.com/tegorov

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/github/GitHub.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/github/GitHub.kt
@@ -65,7 +65,7 @@ enum class GitHubPullRequestState {
 data class GitHubPR(
     val number: Int,
     val title: String,
-    val body: String,
+    val body: String?,
     val user: GitHubUser,
     val assignee: GitHubUser?,
     val assignees: List<GitHubUser>,
@@ -247,7 +247,7 @@ data class GitHubIssue(
     val user: GitHubUser,
     val state: GitHubIssueState,
     @SerialName("locked") val isLocked: Boolean,
-    val body: String,
+    val body: String?,
     @SerialName("comments") val commentCount: Int,
     val assignee: GitHubUser?,
     val assignees: List<GitHubUser>,


### PR DESCRIPTION
I'm getting this error when trying to run Danger from CI (Github Actions):
```
kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 4707: Expected string or non-null literal
JSON input: .....h"
        },
        "body": null,
        "closed_by": nul.....
	at kotlinx.serialization.json.internal.JsonExceptionsKt.JsonDecodingException(JsonExceptions.kt:24)
	at kotlinx.serialization.json.internal.JsonExceptionsKt.JsonDecodingException(JsonExceptions.kt:32)
	at kotlinx.serialization.json.internal.JsonReader.fail(JsonReader.kt:333)
	at kotlinx.serialization.json.internal.JsonReader.takeString(JsonReader.kt:147)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeString(StreamingJsonDecoder.kt:210)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeStringElement(AbstractDecoder.kt:56)
	at systems.danger.kotlin.models.github.GitHubIssue$$serializer.deserialize(GitHub.kt:242)
	at systems.danger.kotlin.models.github.GitHubIssue$$serializer.deserialize(GitHub.kt:242)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:63)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:33)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:41)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:63)
	at systems.danger.kotlin.models.github.GitHub$$serializer.deserialize(GitHub.kt:13)
	at systems.danger.kotlin.models.github.GitHub$$serializer.deserialize(GitHub.kt:13)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:63)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:33)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:41)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeNullableSerializableElement(AbstractDecoder.kt:72)
	at systems.danger.kotlin.models.danger.DangerDSL$$serializer.deserialize(DangerDSL.kt:14)
	at systems.danger.kotlin.models.danger.DangerDSL$$serializer.deserialize(DangerDSL.kt:14)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:63)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:33)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:41)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:63)
	at systems.danger.kotlin.models.danger.DSL$$serializer.deserialize(DangerDSL.kt:9)
	at systems.danger.kotlin.models.danger.DSL$$serializer.deserialize(DangerDSL.kt:9)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:63)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:33)
	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:85)
	at systems.danger.kotlin.MainDangerRunner.<init>(MainDangerRunner.kt:124)
	at systems.danger.kotlin.MainScriptKt.Danger(MainScript.kt:44)
	at Dangerfile_df.<init>(Dangerfile.df.kts:39)
```
If a pull request is created through github api without body parameter, then body parameter will be null
For verification, I created pull request through github api: https://github.com/tegorov/kotlin/pull/1