### PR TITLE
Improving error message for when a DangerPlugin was not registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -->
 ## Master
 
+- Improving error message for when a DangerPlugin was not registered [@rojanthomas] - [#181](https://github.com/danger/kotlin/pull/181)
 - Fix body parameter in github models  [@tegorov] - [#175](https://github.com/danger/kotlin/pull/175)
 
 # 1.0.0-beta2
@@ -71,3 +72,4 @@
 [@uzzu]: https://github.com/uzzu
 [@mariusgreve]: https://github.com/mariusgreve
 [@tegorov]: https://github.com/tegorov
+[@rojanthomas]: https://github.com/rojanthomas

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/MainPlugins.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/MainPlugins.kt
@@ -80,5 +80,5 @@ inline fun register(block: register.() -> Unit) = register.run(block)
  * @param dangerContext the [DangerContext]
  */
 internal fun DangerPlugin.withContext(dangerContext: DangerContext) {
-    context = dangerContext
+    registeredContext = dangerContext
 }

--- a/danger-kotlin-sdk/src/main/kotlin/systems/danger/kotlin/sdk/DangerKotlinAPI.kt
+++ b/danger-kotlin-sdk/src/main/kotlin/systems/danger/kotlin/sdk/DangerKotlinAPI.kt
@@ -146,6 +146,21 @@ abstract class DangerPlugin {
     // The plugin unique id
     abstract val id: String
 
-    // The DangerContext
-    lateinit var context: DangerContext
+    /**
+     * The context that will be set by the danger runner. This wil be null if the plugin has not been registered in the
+     * Dangerfile.
+     */
+    var registeredContext : DangerContext? = null
+
+    /**
+     * Provides a backing getter around registeredContext to avoid null checks if we know the plugin must be registered
+     * in the Dangerfile.
+     *
+     * @throws NullPointerException if the plugin was not registered in the Dangerfile.
+     */
+    val context : DangerContext
+        get() = registeredContext ?: throw NullPointerException(
+            "DangerContext is null! Have you registered this plugin in your Dangerfile e.g. " +
+                    "'register plugin ${this::class.simpleName}'?"
+        )
 }


### PR DESCRIPTION
I forgot to register my plugin when developing a plugin and the error was `kotlin.UninitializedPropertyAccessException: lateinit property context has not been initialized`.

We could improve it to inform the developer that they would need to register the plugin first e.g. `java.lang.NullPointerException: DangerContext is null! Have you registered this plugin in your Dangerfile e.g. 'register plugin DangerKotlinJira'?`