### PR TITLE
Make force_remove_source_branch nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 -->
 ## Master
 
+- Make `force_remove_source_branch` nullable in GitLab Merge request entity [@davidbilik] - [#197](https://github.com/danger/kotlin/pull/197)
+
 # 1.0.0-beta4, 1.0.0
 
 - Create the Danger main instance only once [@f-meloni] - [#185](https://github.com/danger/kotlin/pull/185)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
@@ -54,7 +54,7 @@ data class GitLabMergeRequest(
     @SerialName("first_deployed_to_production_at")
     val firstDeployedToProductionAt: Instant? = null,
     @SerialName("force_remove_source_branch")
-    val forceRemoveSourceBranch: Boolean,
+    val forceRemoveSourceBranch: Boolean?,
     val id: Int,
     val iid: Int,
     @SerialName("latest_build_finished_at")


### PR DESCRIPTION
When making a MR from a protected branch (eg. `devel` to `stage`) 
this attribute is null and parsing fails.