### PR TITLE
Make user nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -->
 ## Master
 - Update `Kotlin` to `1.7.0` and added support for Apple Silicon Chipset [@gianluz] - [#231](https://github.com/danger/kotlin/pull/231)
+- Make user property nullable for cases when non BB user did a commit [@vchernyshov]
 
 # 1.1.1
 - Make GitLab approvals_before_merge variable nullable [#227](https://github.com/danger/kotlin/pull/227)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/bitbucket/BitBucketCloud.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/bitbucket/BitBucketCloud.kt
@@ -32,7 +32,7 @@ data class BitBucketCloud(
         @SerialName("updated_on")
         val updatedOn: Instant,
         val deleted: Boolean,
-        val user: User,
+        val user: User? = null,
     )
 
     @Serializable

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/bitbucket/BitBucketCloud.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/bitbucket/BitBucketCloud.kt
@@ -63,7 +63,7 @@ data class BitBucketCloud(
         @Serializable
         data class Author(
             val raw: String,
-            val user: User
+            val user: User?
         )
     }
 
@@ -99,7 +99,7 @@ data class BitBucketCloud(
         data class Participant(
             val approved: Boolean,
             val role: Role,
-            val user: User
+            val user: User?
         ) {
 
             @Serializable

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/bitbucket/BitBucketCloud.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/bitbucket/BitBucketCloud.kt
@@ -63,7 +63,7 @@ data class BitBucketCloud(
         @Serializable
         data class Author(
             val raw: String,
-            val user: User?
+            val user: User? = null
         )
     }
 
@@ -99,7 +99,7 @@ data class BitBucketCloud(
         data class Participant(
             val approved: Boolean,
             val role: Role,
-            val user: User?
+            val user: User? = null
         ) {
 
             @Serializable


### PR DESCRIPTION
In some cases PR could contain commits from non BB user, in this case api could not recognise such user and as the result user property is null, as model has non nullable property Danger Kotlin simple crashes. This PR fixes this corner case.