### PR TITLE
fix(danger-kotlin): allow to add space separated args

### DIFF
--- a/danger-kotlin/src/runnerMain/kotlin/Main.kt
+++ b/danger-kotlin/src/runnerMain/kotlin/Main.kt
@@ -25,7 +25,7 @@ fun main(args: Array<String>) {
             else -> {
                 when (val command = Command.forArgument(args.first())) {
                     Command.CI, Command.LOCAL, Command.PR -> {
-                        DangerJS.process(command, PROCESS_DANGER_KOTLIN, args.drop(1))
+                        DangerJS.process(command, PROCESS_DANGER_KOTLIN, args.drop(1).map { if(it.contains(" ")) "'$it'" else it })
                     }
                     Command.RUNNER -> DangerKotlin.run()
                     else -> Log.error("Invalid command received: $command")


### PR DESCRIPTION
Fixing issue with space separated args. 
For example Kotlin CLI:  `... --id "My space separated ID"` -> JS CLI: `--id My space separated ID` 
It can create issue as well if space separated args will be added in the middle of parameters string
F.E. `--id "My space separated ID" --danger-file /foo/d.df.kts`