### PR TITLE
Update README.md with correct advise for using the docker image in GHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: "Run Danger"
+    container:
+      image: docker://ghcr.io/danger/danger-kotlin:1.3.1
     steps:
-      - uses: actions/checkout@v1
-      - name: Danger
-        uses: docker://ghcr.io/danger/danger-kotlin:1.3.1
+      - uses: actions/checkout@v4
+      - name: Run Danger
         run: danger-kotlin ci --failOnErrors --no-publish-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current advice for using the docker image, post v1.3.0, is incorrect for GitHub actions as it will error saying you can't use `uses` and `run` in the same step.

Instead you must setup the image as a `container:` on the job and then execute the runs in a step

You can see an example of this working on my PR here: https://github.com/r0adkll/kimchi/pull/11