### PR TITLE
Make MR descriptions optional

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
@@ -47,7 +47,7 @@ data class GitLabMergeRequest(
     val closedAt: Instant? = null,
     @SerialName("closed_by")
     val closedBy: GitLabUser? = null,
-    val description: String,
+    val description: String? = null,
     @SerialName("diff_refs")
     val diffRefs: GitLabDiffRefs,
     val downvotes: Int,


### PR DESCRIPTION
I'm mainly a swift developer, but I noticed that some danger jobs were failing to parse the response from GitLab if descriptions were blank and found where [danger-swift](https://github.com/danger/swift/pull/609) updated their model to allow description to be optional and figured it should also be here.