### PR TITLE
danger-kotlin cannot compile on Xcode 15+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Kotlin
         run: |
-          curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v1.7.22/kotlin-compiler-1.7.22.zip
+          curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v2.0.10/kotlin-compiler-2.0.10.zip
           
           if [[ "$OSTYPE" != "darwin"* ]]
           then

--- a/.github/workflows/docker_manual.yml
+++ b/.github/workflows/docker_manual.yml
@@ -12,7 +12,7 @@ on:
         description: "Danger Kotlin release version"
       kotlin-version:
         description: "Kotlin Version"
-        default: "1.7.22"
+        default: "2.0.10"
 
 jobs:
   docker-build-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL "com.github.actions.description"="Runs Kotlin Dangerfiles"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
-ARG KOTLINC_VERSION="1.7.22"
+ARG KOTLINC_VERSION="2.0.10"
 ARG DANGER_KOTLIN_VERSION="1.3.1"
 ARG DANGER_JS_VERSION="11.3.1"
 

--- a/danger-kotlin-sample-plugin/build.gradle
+++ b/danger-kotlin-sample-plugin/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.7.22'
+    id 'org.jetbrains.kotlin.jvm' version '2.0.10'
 }
 
 apply plugin: 'danger-kotlin-plugin-installer'

--- a/danger-kotlin/src/runnerMain/kotlin/Main.kt
+++ b/danger-kotlin/src/runnerMain/kotlin/Main.kt
@@ -7,6 +7,7 @@ import systems.danger.cmd.dangerjs.DangerJS
 const val PROCESS_DANGER_KOTLIN = "danger-kotlin"
 const val VERSION = "1.3.1"
 
+@kotlinx.cinterop.ExperimentalForeignApi
 fun main(args: Array<String>) {
     Log.isVerbose = args.contains("--verbose") || (getenv("DEBUG")?.toString()?.isNotEmpty() ?: false)
     Log.info("Starting Danger-Kotlin $VERSION with args '${args.joinToString(", ")}'", verbose = true)

--- a/danger-kotlin/src/runnerMain/kotlin/systems.danger/DangerKotlin.kt
+++ b/danger-kotlin/src/runnerMain/kotlin/systems.danger/DangerKotlin.kt
@@ -5,6 +5,7 @@ import systems.danger.cmd.dangerfile.DangerFile
 object DangerKotlin {
     private const val FILE_TMP_OUTPUT_JSON = "danger_out.json"
 
+    @kotlinx.cinterop.ExperimentalForeignApi
     fun run() {
         val dangerDSLPath = readLine()
 

--- a/danger-kotlin/src/runnerMain/kotlin/systems.danger/cmd/dangerfile/DangerFile.kt
+++ b/danger-kotlin/src/runnerMain/kotlin/systems.danger/cmd/dangerfile/DangerFile.kt
@@ -15,6 +15,7 @@ object DangerFile : DangerFileBridge {
         "/usr", // Fallback
     )
 
+    @kotlinx.cinterop.ExperimentalForeignApi
     override fun execute(inputJson: String, outputJson: String) {
         val dangerKotlinJarPath = platformExpectedLibLocations
             .map { "$it/lib/danger/danger-kotlin.jar" }
@@ -48,6 +49,7 @@ object DangerFile : DangerFileBridge {
     }
 }
 
+@kotlinx.cinterop.ExperimentalForeignApi
 private fun dangerfileParameter(inputJson: String): String? {
     var result: String? = null
 
@@ -69,6 +71,7 @@ private fun dangerfileParameter(inputJson: String): String? {
     return result
 }
 
+@kotlinx.cinterop.ExperimentalForeignApi
 private fun readLine(file: CPointer<FILE>): String? {
     var ch = getc(file)
     var lineBuffer: Array<Char> = arrayOf()

--- a/dependencyVersions.gradle
+++ b/dependencyVersions.gradle
@@ -20,7 +20,7 @@ project.ext.groupIdOkio = 'com.squareup.okio'
 project.ext.artifactIdOkio = 'okio'
 
 // Kotlin
-project.ext.versionKotlin = '1.7.22'
+project.ext.versionKotlin = '2.0.10'
 project.ext.groupIdKotlin = 'org.jetbrains.kotlin'
 project.ext.groupIdKotlinx = 'org.jetbrains.kotlinx'
 project.ext.artifactIdKotlinMain = 'kotlin-main-kts'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-kotlinVersion=1.7.22
+kotlinVersion=2.0.10
 kotlin.code.style=official
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,8 +31,8 @@ if [[ -n "$sudo" && "$OSTYPE" != "darwin"* ]]; then
 fi
 
 if ! [[ -x "$(command -v kotlinc)" ]]; then
-    echo "Installing kotlin compiler 1.7.22"
-    curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v1.7.22/kotlin-compiler-1.7.22.zip
+    echo "Installing kotlin compiler 2.0.10"
+    curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v2.0.10/kotlin-compiler-2.0.10.zip
     unzip -d /usr/local/ kotlin-compiler.zip
     echo 'export PATH=/usr/local/kotlinc/bin:$PATH' >> ~/.bash_profile
     rm -rf kotlin-compiler.zip


### PR DESCRIPTION
danger-kotlin will not compile on native mac using Xcode 15+. This seems to be due to Kotlin. Kotlin seems to have resolved this in version [1.9.10](https://youtrack.jetbrains.com/issue/KT-60230).

I don't know Kotlin tooling that well, so please let me know if I've missed anything in this PR that needs to be addressed. I was able to run the gradlew commands in the make file and all of them build successfully.

Thanks!