### PR TITLE
Fix using `head_pipeline` instead of `pipeline` in GitLab

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
@@ -73,6 +73,7 @@ data class GitLabMergeRequest(
     @SerialName("merge_when_pipeline_succeeds")
     val mergeOnPipelineSuccess: Boolean,
     val milestone: GitLabMilestone? = null,
+    @SerialName("head_pipeline")
     val pipeline: GitLabPipeline,
     @SerialName("project_id")
     val projectId: String,

--- a/danger-kotlin-library/src/test/resources/gitlabDangerJSON.json
+++ b/danger-kotlin-library/src/test/resources/gitlabDangerJSON.json
@@ -113,14 +113,14 @@
         "latest_build_started_at": "2021-04-30T14:35:00.103+02:00",
         "latest_build_finished_at": "2019-04-11T00:33:22.492Z",
         "first_deployed_to_production_at": "2019-04-11T00:30:22.492Z",
-        "pipeline": {
+        "pipeline": null,
+        "head_pipeline": {
           "id": 50,
           "sha": "621bc3348549e51c5bd6ea9f094913e9e4667c7b",
           "ref": "ef28580bb2a00d985bffe4a4ce3fe09fdb12283f",
           "status": "success",
           "web_url": "https://gitlab.com/danger-systems/danger.systems/pipeline/621bc3348549e51c5bd6ea9f094913e9e4667c7b"
         },
-        "head_pipeline": null,
         "diff_refs": {
           "base_sha": "ef28580bb2a00d985bffe4a4ce3fe09fdb12283f",
           "head_sha": "621bc3348549e51c5bd6ea9f094913e9e4667c7b",

--- a/danger-kotlin-library/src/test/resources/gitlabWithCancelledPipelineDangerJSON.json
+++ b/danger-kotlin-library/src/test/resources/gitlabWithCancelledPipelineDangerJSON.json
@@ -113,14 +113,14 @@
         "latest_build_started_at": "2021-04-30T14:35:00.103+02:00",
         "latest_build_finished_at": "2019-04-11T00:33:22.492Z",
         "first_deployed_to_production_at": "2019-04-11T00:30:22.492Z",
-        "pipeline": {
+        "pipeline": null,
+        "head_pipeline": {
           "id": 50,
           "sha": "621bc3348549e51c5bd6ea9f094913e9e4667c7b",
           "ref": "ef28580bb2a00d985bffe4a4ce3fe09fdb12283f",
           "status": "canceled",
           "web_url": "https://gitlab.com/danger-systems/danger.systems/pipeline/621bc3348549e51c5bd6ea9f094913e9e4667c7b"
         },
-        "head_pipeline": null,
         "diff_refs": {
           "base_sha": "ef28580bb2a00d985bffe4a4ce3fe09fdb12283f",
           "head_sha": "621bc3348549e51c5bd6ea9f094913e9e4667c7b",


### PR DESCRIPTION
Due to [GitLab docs](https://docs.gitlab.com/ee/api/merge_requests.html) we should prefer using `head_pipeline` instead of `pipeline` as it contains more information.

Additional to that, sometimes I caught crashes on danger-kotlin when `pipeline` status was incorrect in that field or even when `pipeline` field was `null`.
But I can't just mark `pipeline` field as nullable, cause it will cause backward incompatibility.