### PR TITLE
fix(ci): setup permissions set for github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on: pull_request
 
 jobs:
   build:
+    permissions:
+      statuses: write
+      pull-requests: read
+      discussions: write
+      issues: write
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,6 +4,22 @@ on: [pull_request]
 
 jobs:
   build:
+    permissions:
+      actions: write
+      attestations: write
+      checks: write
+      contents: write
+      deployments: write
+      id-token: write
+      issues: write
+      discussions: write
+      packages: write
+      pages: write
+      pull-requests: write
+      repository-projects: write
+      security-events: write
+      statuses: write
+
     runs-on: ubuntu-latest
     name: "Run Danger"
     steps:


### PR DESCRIPTION
Interesting workaround permissions setup:
```
    permissions:
      actions: write
      attestations: write
      checks: write
      contents: write
      deployments: write
      id-token: write
      issues: write
      discussions: write
      packages: write
      pages: write
      pull-requests: write
      repository-projects: write
      security-events: write
      statuses: write
```

Result

```
Could not add a commit status, the GitHub token for Danger does not have access rights.
If the build fails, then danger will use a failing exit code.
```

However 

```
permissions: write-all
```

Working as expected.

---

From private fork comment message not posted, but from repo branch all work as expected
