### PR TITLE
Swap additions and deletions in parsing git diff

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/KtxGit.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/KtxGit.kt
@@ -19,8 +19,8 @@ val Git.changedLines: PullRequestChangedLines
                 val parts = line.split("\\s+".toRegex())
                 (parts[0].toIntOrNull() ?: 0) to (parts[1].toIntOrNull() ?: 0)
             }
-        val additions = additionDeletionPairs.fold(0) { acc, (_, addition) -> acc + addition }
-        val deletions = additionDeletionPairs.fold(0) { acc, (deletion, _) -> acc + deletion }
+        val additions = additionDeletionPairs.fold(0) { acc, (addition, _) -> acc + addition }
+        val deletions = additionDeletionPairs.fold(0) { acc, (_, deletion) -> acc + deletion }
         val commandRawDiffOutput = shellExecutor.execute("git diff $headSha $baseSha")
         return PullRequestChangedLines(additions, deletions, commandRawDiffOutput)
     }

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/KtxGitTest.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/KtxGitTest.kt
@@ -2,7 +2,7 @@ package systems.danger.kotlin
 
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import systems.danger.kotlin.models.git.Git
@@ -41,7 +41,7 @@ internal class GitKtxTest {
         )
     )
 
-    private val expectedResult = PullRequestChangedLines(22, 8, diffCommandOutput)
+    private val expectedResult = PullRequestChangedLines(8, 22, diffCommandOutput)
 
     @Before
     fun setup() {


### PR DESCRIPTION
- Due to [documentation](https://git-scm.com/docs/git-diff) `--numstat` flag at first place shows additions, then tab, then deletions