### PR TITLE
Update libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,6 @@ jobs:
         with:
           node-version: '22.10.0'
 
-      - name: Install libncurses5
-        run: |
-          if [[ "$OSTYPE" == "darwin"* ]]
-          then
-            brew install ncurses
-          else
-            sudo apt-get install libncurses5
-          fi
-
       - name: Install Danger JS
         run: npm install -g danger
        

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,6 +1,14 @@
 name: Release distribution
 
 on:
+  workflow_dispatch:
+    inputs:
+      danger-js-version:
+        description: "Danger JS release version"
+        default: "12.3.3"
+      kotlin-version:
+        description: "Kotlin Version"
+        default: "2.0.21"
   release:
     types: [ created ]
 
@@ -99,9 +107,11 @@ jobs:
           USERNAME: ${{ github.actor }}
 
       - name: Docker Build
-        run: docker build -t ghcr.io/danger/danger-kotlin:$VERSION .
+        run: docker build -t ghcr.io/danger/danger-kotlin:$VERSION --build-arg="DANGER_KOTLIN_VERSION=$VERSION" --build-arg="KOTLINC_VERSION=$KOTLINC_VERSION" --build-arg="DANGER_JS_VERSION=$DANGER_JS_VERSION" .
         env:
           VERSION: ${{ steps.get_release.outputs.tag_name }}
+          KOTLINC_VERSION: ${{ github.event.inputs.kotlin-version }}
+          DANGER_JS_VERSION: ${{ github.event.inputs.danger-js-version }}
 
       - name: Deploy
         run: docker push ghcr.io/danger/danger-kotlin:$VERSION

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,14 +1,6 @@
 name: Release distribution
 
 on:
-  workflow_dispatch:
-    inputs:
-      danger-js-version:
-        description: "Danger JS release version"
-        default: "12.3.3"
-      kotlin-version:
-        description: "Kotlin Version"
-        default: "2.0.21"
   release:
     types: [ created ]
 
@@ -107,11 +99,9 @@ jobs:
           USERNAME: ${{ github.actor }}
 
       - name: Docker Build
-        run: docker build -t ghcr.io/danger/danger-kotlin:$VERSION --build-arg="DANGER_KOTLIN_VERSION=$VERSION" --build-arg="KOTLINC_VERSION=$KOTLINC_VERSION" --build-arg="DANGER_JS_VERSION=$DANGER_JS_VERSION" .
+        run: docker build -t ghcr.io/danger/danger-kotlin:$VERSION .
         env:
           VERSION: ${{ steps.get_release.outputs.tag_name }}
-          KOTLINC_VERSION: ${{ github.event.inputs.kotlin-version }}
-          DANGER_JS_VERSION: ${{ github.event.inputs.danger-js-version }}
 
       - name: Deploy
         run: docker push ghcr.io/danger/danger-kotlin:$VERSION

--- a/Dangerfile_ci.df.kts
+++ b/Dangerfile_ci.df.kts
@@ -7,6 +7,7 @@
 
 //Testing plugin
 @file:DependsOn("danger-kotlin-sample-plugin-sample.jar")
+@file:OptIn(kotlin.time.ExperimentalTime::class)
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -64,9 +65,7 @@ danger(args) {
         async { expensiveCheck("4", 5000) }
     }
     val after = Clock.System.now()
-    @OptIn(kotlin.time.ExperimentalTime::class)
     val runningTime = after.minus(before)
-    @OptIn(kotlin.time.ExperimentalTime::class)
     message("Coroutines checks terminated - runningFor $runningTime")
 
     if ((fails + warnings).isEmpty()) {

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "com.github.actions.color"="blue"
 
 ARG KOTLINC_VERSION="2.0.21"
 ARG DANGER_KOTLIN_VERSION="1.3.2"
-ARG DANGER_JS_VERSION="11.3.1"
+ARG DANGER_JS_VERSION="12.3.3"
 
 # Install dependencies
 RUN apt-get update

--- a/dependencyVersions.gradle
+++ b/dependencyVersions.gradle
@@ -27,9 +27,9 @@ project.ext.artifactIdKotlinMain = 'kotlin-main-kts'
 project.ext.artifactIdKotlinSerializationJson = 'kotlinx-serialization-json'
 project.ext.artifactIdKotlinDatetime = "kotlinx-datetime"
 project.ext.artifactIdKotlinCoroutines = "kotlinx-coroutines-core"
-project.ext.versionKotlinSerializationJson = '1.3.2'
-project.ext.versionKotlinDatetime = '0.2.0'
-project.ext.versionKotlinCoroutines = '1.6.2'
+project.ext.versionKotlinSerializationJson = '1.7.3'
+project.ext.versionKotlinDatetime = '0.6.1'
+project.ext.versionKotlinCoroutines = '1.9.0'
 
 ext.kotlin = [
         mainKts: "$groupIdKotlin:$artifactIdKotlinMain:$versionKotlin",

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        gradlePluginPortal()
         mavenCentral()
         mavenLocal()
     }


### PR DESCRIPTION
Due to some strange errors I was not able to compile `Dangerfile_ci.df.kts` on my Mac.  
The error looks like this:
```
java.lang.NoSuchMethodError: 'long kotlin.time.DurationKt.getSeconds(long)'

        at kotlinx.datetime.Instant.minus-5sfh64U(Instant.kt:46)
        at Dangerfile_ci_df.<init>(Dangerfile_ci.df.kts:76)
```
Though there is `OptIn(ExperimentalTime::class)`.

The solution was to update `kotlinx-datetime` library to the latest version.
Also updated `kotlinx-serialization-json` and `kotlinx-coroutines-core` to the versions that use Kotlin 2.0.

P.S. While trying to check my fixes found out that `libncurses5` package doesn't exist on ubuntu-latest. I also was not able to find the reasons for this step on CI.

**UPD**:
Also find out that danger-js version is still 11.3.1 inside danger-kotlin docker image 1.3.2. No build arguments were passed to release job