### PR TITLE
Fix Gitlab Milestone, Author field type

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/git/Git.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/git/Git.kt
@@ -49,6 +49,6 @@ data class GitCommit(
 @Serializable
 data class GitCommitAuthor(
         val name: String,
-        val email: String,
+        val email: String?,
         val date: String
 )

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
@@ -1,14 +1,14 @@
-@file:UseSerializers(DateSerializer::class, LocalDateSerializer::class)
+@file:UseSerializers(DateSerializer::class)
 
 package systems.danger.kotlin.models.gitlab
 
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.serializers.LocalDateIso8601Serializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import systems.danger.kotlin.models.serializers.DateSerializer
-import systems.danger.kotlin.models.serializers.LocalDateSerializer
 
 @Serializable
 data class GitLab(
@@ -147,12 +147,14 @@ data class GitLabMilestone(
     @SerialName("created_at")
     val createdAt: Instant,
     val description: String,
+    @Serializable(with = LocalDateIso8601Serializer::class)
     @SerialName("due_date")
     val dueDate: LocalDate? = null,
     val id: Long,
     val iid: Long,
     @SerialName("project_id")
     val projectID: Long,
+    @Serializable(with = LocalDateIso8601Serializer::class)
     @SerialName("start_date")
     val startDate: LocalDate? = null,
     val state: GitLabMilestoneState,

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/gitlab/GitLab.kt
@@ -1,12 +1,14 @@
-@file:UseSerializers(DateSerializer::class)
+@file:UseSerializers(DateSerializer::class, LocalDateSerializer::class)
 
 package systems.danger.kotlin.models.gitlab
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import systems.danger.kotlin.models.serializers.DateSerializer
+import systems.danger.kotlin.models.serializers.LocalDateSerializer
 
 @Serializable
 data class GitLab(
@@ -146,13 +148,13 @@ data class GitLabMilestone(
     val createdAt: Instant,
     val description: String,
     @SerialName("due_date")
-    val dueDate: Instant? = null,
+    val dueDate: LocalDate? = null,
     val id: Long,
     val iid: Long,
     @SerialName("project_id")
     val projectID: Long,
     @SerialName("start_date")
-    val startDate: Instant? = null,
+    val startDate: LocalDate? = null,
     val state: GitLabMilestoneState,
     val title: String,
     @SerialName("updated_at")

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/serializers/DateSerializer.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/serializers/DateSerializer.kt
@@ -1,7 +1,6 @@
 package systems.danger.kotlin.models.serializers
 
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
@@ -32,24 +31,6 @@ object DateSerializer : KSerializer<Instant> {
         } catch(e: Throwable) {
             Instant.fromEpochMilliseconds(ISO8601DateFormat().parse(value).toInstant().toEpochMilli())
         }
-    }
-}
-
-@ExperimentalSerializationApi
-@Serializer(forClass = LocalDateSerializer::class)
-object LocalDateSerializer : KSerializer<LocalDate> {
-
-    override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor("kotlinx.datetime.LocalDate", PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: LocalDate) {
-        // Implementation not needed for now
-    }
-
-    override fun deserialize(decoder: Decoder): LocalDate {
-        val value = decoder.decodeString()
-
-        return LocalDate.parse(value)
     }
 }
 

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/serializers/DateSerializer.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/serializers/DateSerializer.kt
@@ -1,6 +1,7 @@
 package systems.danger.kotlin.models.serializers
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
@@ -31,6 +32,24 @@ object DateSerializer : KSerializer<Instant> {
         } catch(e: Throwable) {
             Instant.fromEpochMilliseconds(ISO8601DateFormat().parse(value).toInstant().toEpochMilli())
         }
+    }
+}
+
+@ExperimentalSerializationApi
+@Serializer(forClass = LocalDateSerializer::class)
+object LocalDateSerializer : KSerializer<LocalDate> {
+
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("kotlinx.datetime.LocalDate", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: LocalDate) {
+        // Implementation not needed for now
+    }
+
+    override fun deserialize(decoder: Decoder): LocalDate {
+        val value = decoder.decodeString()
+
+        return LocalDate.parse(value)
     }
 }
 

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/models/gitlab/GitLabMilestoneParsingTests.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/models/gitlab/GitLabMilestoneParsingTests.kt
@@ -1,0 +1,33 @@
+package systems.danger.kotlin.models.gitlab
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.decodeFromString
+import org.junit.Assert.*
+import org.junit.Test
+import systems.danger.kotlin.models.danger.DSL
+import systems.danger.kotlin.utils.TestUtils
+import systems.danger.kotlin.utils.TestUtils.JSONFiles
+
+class GitLabMilestoneParsingTests {
+
+    @Test
+    fun testItParsesTheGitLabMilestoneWithNullDates() {
+        val dslWithNullDates: DSL = TestUtils.Json.decodeFromString(JSONFiles.gitlabWithNullMilestoneDatesJSON)
+        val gitLabWithNullDates: GitLab = dslWithNullDates.danger.gitlab
+
+        with(gitLabWithNullDates.mergeRequest.milestone) {
+            assertNotNull(this)
+            assertEquals(1L, this!!.id)
+            assertEquals(2L, this.iid)
+            assertEquals(1000L, this.projectID)
+            assertEquals("Test Milestone", this.title)
+            assertEquals("Test Description", this.description)
+            assertEquals(GitLabMilestoneState.CLOSED, this.state)
+            assertNull(this.dueDate)
+            assertNull(this.startDate)
+            assertEquals(Instant.fromEpochMilliseconds(1554933465346), this.createdAt)
+            assertEquals(Instant.fromEpochMilliseconds(1554933465346), this.updatedAt)
+            assertEquals("https://gitlab.com/milestone", this.webUrl)
+        }
+    }
+}

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/models/gitlab/GitLabParsingTests.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/models/gitlab/GitLabParsingTests.kt
@@ -1,6 +1,7 @@
 package systems.danger.kotlin.models.gitlab
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.decodeFromString
 import org.junit.Assert.*
 import org.junit.Test
@@ -60,11 +61,11 @@ class GitLabParsingTests {
             val expectedMilestone = GitLabMilestone(
                 Instant.fromEpochMilliseconds(1554933465346),
                 "Test Description",
-                Instant.fromEpochMilliseconds(1560124800000),
+                LocalDate.parse("2019-06-10"),
                 1L,
                 2L,
                 1000L,
-                Instant.fromEpochMilliseconds(1554933465346),
+                LocalDate.parse("2019-04-10"),
                 GitLabMilestoneState.CLOSED,
                 "Test Milestone",
                 Instant.fromEpochMilliseconds(1554933465346),

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/utils/TestUtils.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/utils/TestUtils.kt
@@ -40,6 +40,10 @@ object TestUtils {
             loadJSON("gitlabWithCancelledPipelineDangerJSON.json")
         }
 
+        val gitlabWithNullMilestoneDatesJSON by lazy {
+            loadJSON("gitlabWithNullMilestoneDatesJSON.json")
+        }
+
         private fun loadJSON(named: String): String {
             return this.javaClass.classLoader.getResource(named).readText()
         }

--- a/danger-kotlin-library/src/test/resources/gitlabDangerJSON.json
+++ b/danger-kotlin-library/src/test/resources/gitlabDangerJSON.json
@@ -84,10 +84,10 @@
           "title": "Test Milestone",
           "description": "Test Description",
           "state": "closed",
-          "start_date": "2019-04-10T21:57:45.346Z",
+          "start_date": "2019-04-10",
           "created_at": "2019-04-10T21:57:45.346Z",
           "updated_at": "2019-04-10T21:57:45.346Z",
-          "due_date": "2019-06-10T00:00:00.000Z",
+          "due_date": "2019-06-10",
           "web_url": "https://gitlab.com/milestone"
         },
         "merge_when_pipeline_succeeds": false,

--- a/danger-kotlin-library/src/test/resources/gitlabWithNullMilestoneDatesJSON.json
+++ b/danger-kotlin-library/src/test/resources/gitlabWithNullMilestoneDatesJSON.json
@@ -84,10 +84,10 @@
           "title": "Test Milestone",
           "description": "Test Description",
           "state": "closed",
-          "start_date": "2019-04-10",
+          "start_date": null,
           "created_at": "2019-04-10T21:57:45.346Z",
           "updated_at": "2019-04-10T21:57:45.346Z",
-          "due_date": "2019-06-10",
+          "due_date": null,
           "web_url": "https://gitlab.com/milestone"
         },
         "merge_when_pipeline_succeeds": false,
@@ -118,7 +118,7 @@
           "id": 50,
           "sha": "621bc3348549e51c5bd6ea9f094913e9e4667c7b",
           "ref": "ef28580bb2a00d985bffe4a4ce3fe09fdb12283f",
-          "status": "canceled",
+          "status": "success",
           "web_url": "https://gitlab.com/danger-systems/danger.systems/pipeline/621bc3348549e51c5bd6ea9f094913e9e4667c7b"
         },
         "diff_refs": {


### PR DESCRIPTION
### Gitlab Milestone

Refer to https://github.com/danger/kotlin/pull/322

- Gitlab Milestone `due_date` and `start_date` only send a date.

<img width="767" height="621" alt="image" src="https://github.com/user-attachments/assets/484976f9-b5da-42c1-8671-d9082e6ee45f" />

<img width="384" height="192" alt="image" src="https://github.com/user-attachments/assets/f8e80d1f-f0a6-425e-a10f-dec1a4ddca2b" />

### Gitlab Author

- Author email can be null if the user doesn't set a public email address.
